### PR TITLE
#164489784 Swagger documentation for twitter and GitHub login 

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ info:
   version: '0.0.1'
   title: Author Haven
 # during dev, should point to your local machine
-host: localhost:10010
+host: localhost:3000
 # basePath prefixes all resource paths
 basePath: /
 #
@@ -37,3 +37,17 @@ paths:
           # responses may fall through to errors
           default:
             description: Unexpected Error
+  /api/auth/twitter:
+    # binds a127 app logic to a route
+    get:
+      description: Login with Twitter
+      responses:
+        '200':
+          description: Redirects to twitter
+  /api/auth/twitter/callback:
+    # binds a127 app logic to a route
+    get:
+      description: Login with Twitter Callback
+      responses:
+        '200':
+          description: Returns an object with data from twitter

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -51,17 +51,17 @@ paths:
       responses:
         '200':
           description: Returns an object with data from twitter
-  /api/auth/facebook:
+  /api/auth/github:
     # binds a127 app logic to a route
     get:
-      description: Login with Facebook
+      description: Login with Github
       responses:
         '200':
-          description: Redirects to Facebook
-  /api/auth/facebook/callback:
+          description: Redirects to Github
+  /api/auth/github/callback:
     # binds a127 app logic to a route
     get:
-      description: Login with Facebook Callback
+      description: Login with Github Callback
       responses:
         '200':
-          description: Returns an object with data from Facebook
+          description: Returns an object with data from Github

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -51,3 +51,17 @@ paths:
       responses:
         '200':
           description: Returns an object with data from twitter
+  /api/auth/facebook:
+    # binds a127 app logic to a route
+    get:
+      description: Login with Facebook
+      responses:
+        '200':
+          description: Redirects to Facebook
+  /api/auth/facebook/callback:
+    # binds a127 app logic to a route
+    get:
+      description: Login with Facebook Callback
+      responses:
+        '200':
+          description: Returns an object with data from Facebook


### PR DESCRIPTION
#### What does this PR do?
- It documents endpoints of login with GitHub and twitter
#### Description of Task to be completed?
- 4 endpoints are documented, these are "api/auth/twitter", "api/auth/twitter/callback", "api/auth/github", "api/auth/github/callback", 
#### How should this be manually tested?
- It can be manually tested by visiting the documentation on {{URL}}/api-docs/
#### Any background context you want to provide?
- This work was missing in the Login with Twitter and Github PR
#### What are the relevant pivotal tracker stories?
- None
#### Screenshots (if appropriate)
- None
#### Questions:
- None