### PR TITLE
Chore fix ordering of comment and number of history returned

### DIFF
--- a/controllers/articlecomment.js
+++ b/controllers/articlecomment.js
@@ -61,7 +61,7 @@ class ArticleComment {
       const comments = [];
 
       await Promise.all(comment.map(async (entry) => {
-        const historyData = await CommentHistoryModel.findAll({ where: { commentid: entry.id } });
+        const historyData = await CommentHistoryModel.findAll({ where: { commentid: entry.id }, order: [['id', 'DESC']], limit: 5 });
         const history = [];
         historyData.forEach((data) => {
           const historyDetails = select.pick(data, ['oldcomment', 'createdAt']);

--- a/models/articlecomment.js
+++ b/models/articlecomment.js
@@ -8,7 +8,7 @@ const ArticleCommentModel = (Sequelize, DataTypes) => {
     freezeTableName: true, // Model tableName will be the same as the model name
   });
   ArticleComment.listComments = async (articleId, type) => {
-    const ordering = (type === 'popular') ? 'ORDER BY likes DESC' : 'ORDER BY id DESC';
+    const ordering = (type === 'popular') ? 'ORDER BY articlecomment.likes DESC' : 'ORDER BY articlecomment.id DESC';
     const result = await Sequelize.query(
       `SELECT users.id AS userid, users.username, users.bio, users.image, articlecomment.* FROM users, articlecomment WHERE users.id = articlecomment.userid AND articlecomment.articleid = ${articleId} ${ordering}`,
       { type: Sequelize.QueryTypes.SELECT },


### PR DESCRIPTION
#### What does this PR do?
- Orders comment and limits returned history
#### Description of Task to be completed?
- This PR fixes issues in Ordering comment returned. It now orders them by the latest and also limits edit history returned to the latest five only.
#### How should this be manually tested?
 - None
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
