### PR TITLE
#166815539 fix bug user read unread notification

### DIFF
--- a/migrations/20190424163354-create-notifications.js
+++ b/migrations/20190424163354-create-notifications.js
@@ -21,6 +21,11 @@ module.exports = {
     link: {
       type: Sequelize.TEXT
     },
+    status: {
+      type: Sequelize.STRING,
+      defaultValue: 'Unread'
+
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/models/notifications.js
+++ b/models/notifications.js
@@ -4,6 +4,7 @@ const notificationModel = (sequelize, DataTypes) => {
     category: DataTypes.STRING,
     message: DataTypes.STRING,
     link: DataTypes.TEXT,
+    status: DataTypes.STRING
   }, {});
   Notifications.associate = (models) => {
     Notifications.belongsTo(models.user, { foreignKey: 'userid', onDelete: 'CASCADE' });
@@ -13,8 +14,14 @@ const notificationModel = (sequelize, DataTypes) => {
       userid, category, message, link,
     });
   };
-  Notifications.findAllNotification = userid => Notifications.findAll({ where: { userid } });
-  Notifications.read = (id, userid) => Notifications.update({ status: 'read' }, { where: { id, userid } });
+  Notifications.findAllNotification = userid => Notifications.findAll({
+    where: { userid },
+    order: [
+      ['status', 'DESC'],
+      ['createdAt', 'DESC']
+    ]
+  });
+  Notifications.read = (id, userid) => Notifications.update({ status: 'Read' }, { where: { id, userid } });
   return Notifications;
 };
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "NODE_ENV=test npm run migrate && NODE_ENV=test nyc --reporter=html --reporter=text mocha --require @babel/polyfill --require @babel/register ./test/*.js --exit",
     "start": "babel-node ./index.js",
     "migrate": "node_modules/.bin/sequelize db:migrate:undo:all && node_modules/.bin/sequelize db:migrate",
+    "addChanges": "node_modules/.bin/sequelize db:migrate",
     "dev": "nodemon --exec babel-node ./index.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint ./",


### PR DESCRIPTION
#### What does this PR do?
This PR retrieve notification of a user and sort them by unread ones.
#### Description of Task to be completed?
- Included an attribute of sorting notifications as an instance method of notification model. 
#### How should this be manually tested?
- Clone this repo https://github.com/andela/strikers-ah-backend.git 
- Open a folder where you cloned this repo and open Terminal/cmd there.
- Checkout to develop branch by typing `git checkout develop` in your opened terminal.
- Type `npm install` to install all dependencies needed for this app.
- Type `npm start` to start the server.
- To see all notification you can access `localhost:5000/api/profiles/notifications` route through postman.
#### Any background context you want to provide?
- Use `postman` chrome extension to access app routes.
#### What are the relevant pivotal tracker stories?
#166815539
#### Screenshots (if appropriate)
<img width="1135" alt="Screen Shot 2019-06-20 at 16 00 12" src="https://user-images.githubusercontent.com/37753967/59855088-86e2a300-9374-11e9-9146-1d9ca9566e05.png">